### PR TITLE
Deactivate scanning

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -41,9 +41,10 @@ jobs:
     with:
       rock: "user-verification-service"
       structure-tests-enabled: true
-  scan:
-    if: ${{ (github.ref == 'refs/heads/main') || (github.ref_type == 'tag') }}
-    needs: gh-publish
-    uses: canonical/identity-team/.github/workflows/_rock-scan.yaml@v1.8.0
-    with:
-      image: ${{ needs.gh-publish.outputs.image }}
+  # codeql actions are not enabled for internal repos
+  # scan:
+  #   if: ${{ (github.ref == 'refs/heads/main') || (github.ref_type == 'tag') }}
+  #   needs: gh-publish
+  #   uses: canonical/identity-team/.github/workflows/_rock-scan.yaml@v1.8.0
+  #   with:
+  #     image: ${{ needs.gh-publish.outputs.image }}

--- a/.github/workflows/ossf.yaml
+++ b/.github/workflows/ossf.yaml
@@ -25,6 +25,7 @@ jobs:
       - name: "Checkout code"
         uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
         with:
+          token: ${{ secrets.PAT_TOKEN }}
           persist-credentials: false
 
       - name: "Run analysis"


### PR DESCRIPTION
Codeql security scanning is not enabled right now for internal repos. IS and security will have to discuss it internally, until then we have to turn the scanning action off.