### PR TITLE
Add SALESFORCE_ENABLED flag

### DIFF
--- a/internal/config/specs.go
+++ b/internal/config/specs.go
@@ -17,6 +17,7 @@ type EnvSpec struct {
 	ErrorUiUrl   string `envconfig:"error_ui_url" default:""`
 	SupportEmail string `envconfig:"support_email" default:""`
 
+	SalesforceEnabled        bool   `envconfig:"salesforce_enabled" default:"true"`
 	SalesforceDomain         string `envconfig:"salesforce_domain"`
 	SalesforceConsumerKey    string `envconfig:"salesforce_consumer_key"`
 	SalesforceConsumerSecret string `envconfig:"salesforce_consumer_secret"`

--- a/internal/salesforce/noop.go
+++ b/internal/salesforce/noop.go
@@ -1,0 +1,32 @@
+package salesforce
+
+import (
+	"context"
+
+	"github.com/canonical/user-verification-service/internal/logging"
+	"github.com/canonical/user-verification-service/internal/monitoring"
+	"github.com/canonical/user-verification-service/internal/tracing"
+)
+
+type NoopClient struct {
+	tracer  tracing.TracingInterface
+	monitor monitoring.MonitorInterface
+	logger  logging.LoggerInterface
+}
+
+func (c *NoopClient) IsEmployee(ctx context.Context, mail string) (bool, error) {
+	// always return false in order to prevent security vulnerabilities when using this client by accident
+	return false, nil
+}
+
+func NewNoopClient(
+	tracer tracing.TracingInterface,
+	monitor monitoring.MonitorInterface,
+	logger logging.LoggerInterface,
+) *NoopClient {
+	c := new(NoopClient)
+	c.logger = logger
+	c.monitor = monitor
+	c.tracer = tracer
+	return c
+}

--- a/pkg/user_verification/service.go
+++ b/pkg/user_verification/service.go
@@ -25,14 +25,14 @@ func (s *Service) IsEmployee(ctx context.Context, email string) (bool, error) {
 }
 
 func NewService(
-	d salesforce.SalesforceAPI,
+	sf salesforce.SalesforceAPI,
 	tracer tracing.TracingInterface,
 	monitor monitoring.MonitorInterface,
 	logger logging.LoggerInterface,
 ) *Service {
 	s := new(Service)
 
-	s.salesforce = d
+	s.salesforce = sf
 
 	s.monitor = monitor
 	s.tracer = tracer

--- a/pkg/web/router.go
+++ b/pkg/web/router.go
@@ -36,7 +36,7 @@ func NewRouter(
 	supportEmail,
 	token,
 	uiBaseURL string,
-	d salesforce.SalesforceAPI,
+	sf salesforce.SalesforceAPI,
 	tracer tracing.TracingInterface,
 	monitor monitoring.MonitorInterface,
 	logger logging.LoggerInterface,
@@ -67,7 +67,7 @@ func NewRouter(
 
 	uiRouter := chi.NewMux()
 
-	userVerification.NewAPI(userVerification.NewService(d, tracer, monitor, logger), authMiddleware, logger).RegisterEndpoints(router)
+	userVerification.NewAPI(userVerification.NewService(sf, tracer, monitor, logger), authMiddleware, logger).RegisterEndpoints(router)
 	ui.NewAPI(errorUiUrl, supportEmail, logger).RegisterEndpoints(router)
 	metrics.NewAPI(logger).RegisterEndpoints(router)
 	status.NewAPI(tracer, monitor, logger).RegisterEndpoints(router)


### PR DESCRIPTION
Add `SALESFORCE_ENABLED` flag to allow the server to run without the salesforce config. This is needed for the charm's integration tests. Without this change the server will fail to start when the salesforce config in not provided as it tries to authenticate with salesforce on start.